### PR TITLE
Fixed XSS Vulnerability of both the username as well as the forum post

### DIFF
--- a/Frontend/src/app/components/home/home.component.ts
+++ b/Frontend/src/app/components/home/home.component.ts
@@ -33,15 +33,16 @@ public entries : string;
     }
   }
 
+  // We have to modify the method that causes XSS
   public convertToHTML(entries : forumEntry[]) : string{
     var entriesContainer = document.getElementById('forumposts');
     let htmlString = '';
 
     entries.forEach(entry => {
       if (entriesContainer != null){
-        entriesContainer.innerHTML = entriesContainer.innerHTML.concat('<h2>' + entry.Author + '</h2><br>' + entry.Text);
-      }
-    });
+        entriesContainer.innerHTML = entriesContainer.innerHTML.concat('<h2>' + this.escapeCharactersForHtmlDisplay(entry.Author) + '</h2><br>' + this.escapeCharactersForHtmlDisplay(entry.Text)); // This is the problem, right here
+      }                                                                                                                   // The untrusted data is added to the HTML code,  
+    });                                                                                                                   // namely "entry.Author" as well as "entry.Text"
    
 //    alert(entriesContainer?.innerHTML);
        // htmlString = htmlString.concat('<img src="' + element.Text + '"/>');
@@ -50,6 +51,19 @@ public entries : string;
 
     return htmlString;
   }
+
+  // We also have to create our own method to escape characters that will we injected, or concatenated in the HTML
+  public escapeCharactersForHtmlDisplay(inputToEscape: string) : string{
+    const ESC_MAP: {[index: string]: any} = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      "/": '&#x2F;'};
+      const reg = /[&<>"'/]/ig;
+      return inputToEscape.replace(reg, (match)=>(ESC_MAP[match]));    
+  } 
 
   public onSubmitEntry() : void{
     let newEntry = new forumEntry(this.forumPost, this.author);


### PR DESCRIPTION
* Added a custom Method escapeCharactersForHtmlDisplay

* Implemented the escapeCharactersForHtmlDisplay inside the convertToHtml Method

The number one rule of OWASP Cross-Site Scripting Prevention is "_HTML Encode Before Inserting Untrusted Data Into HTML Element Content_". This should be applied every time that untrusted data is applied **directly into the HTML** body somewhere. This includes tags such as: `div`, `p`, `b`,  `td`. <br>

So what needs to be done is the following: "_Untrusted code needs to be converted into a safe form where the input is displayed as data to the user without executing as code in the browser_". <br >

In order to achieve that, the following needs to be converted:

* `&` to `&amp;`
*  `<` to `&lt;` 
* `>` to `&gt;`
* `"` to `&quot;`
* `'` to `&#x27;`
* `/` to `&#x2F;`


_Source:_
https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html